### PR TITLE
Ignore "warning: mismatched indentations" for generated files during tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     racc (1.4.15)
     rack (2.0.6)
     rake (12.3.2)
+    warning (0.10.1)
 
 PLATFORMS
   ruby
@@ -21,6 +22,7 @@ DEPENDENCIES
   minitest (~> 5.11.3)
   racc (~> 1.4.15)
   rake (~> 12.3.2)
+  warning (~> 0.10.1)
 
 BUNDLED WITH
    1.17.2

--- a/halunke.gemspec
+++ b/halunke.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rack", "~> 2.0.4"
 
+  spec.add_development_dependency "warning", "~> 0.10.1"
   spec.add_development_dependency "bundler", "~> 1.17.2"
   spec.add_development_dependency "rake", "~> 12.3.2"
   spec.add_development_dependency "minitest", "~> 5.11.3"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "halunke"
 
+# NB: Since both parser.rb and tokenizer.rb are generated and contain some mismatched indentations we want to ignore those warnings.
+require "warning"
+Warning.ignore(/warning: mismatched indentations/, File.expand_path("../../lib/halunke/parser.rb", __FILE__))
+Warning.ignore(/warning: mismatched indentations/, File.expand_path("../../lib/halunke/tokenizer.rb", __FILE__))
+
 require "minitest/autorun"


### PR DESCRIPTION
Running `rake test` for Halunke results in this warning output:

```
halunke git:master ❯ rake                                                                                                                                                                                                                   ✹
ragel -R -o lib/halunke/tokenizer.rb lib/halunke/tokenizer.rl
racc -o lib/halunke/parser.rb lib/halunke/grammar.y
/Users/dbreuer/Code/halunke/test/test_helper.rb:4: warning: assigned but unused variable - a
/Users/dbreuer/Code/halunke/lib/halunke/parser.rb:256: warning: mismatched indentations at 'end' with 'module' at 13
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:271: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:276: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:280: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:284: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:290: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:296: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:302: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:308: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:314: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:320: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:326: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:332: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:338: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:344: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:350: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:356: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:361: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:367: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:373: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:379: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:385: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:391: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:397: warning: mismatched indentations at 'when' with 'case' at 270
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:407: warning: mismatched indentations at 'end' with 'case' at 400
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:408: warning: mismatched indentations at 'end' with 'begin' at 399
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:425: warning: mismatched indentations at 'when' with 'case' at 424
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:448: warning: mismatched indentations at 'end' with 'if' at 442
/Users/dbreuer/Code/halunke/lib/halunke/tokenizer.rb:454: warning: mismatched indentations at 'end' with 'begin' at 176
```

Since the two affected files (`parser.rb` and `tokenizer.rb`) are generated we can safely ignore those warnings. But since `Rake::TestTask` sets the Ruby warning level to `2` we need to get creative to suppress the warnings. We added the [`warnings` gem](https://github.com/jeremyevans/ruby-warning) to easily the ignore those warnings in just the affected files and just in tests.