### PR TITLE
Improve error message display implementation

### DIFF
--- a/lib/halunke/source_code_position.rb
+++ b/lib/halunke/source_code_position.rb
@@ -12,8 +12,7 @@ module Halunke
 
       line, line_number = source.lines.each_with_index.find do |candidate, _line_number|
         if ts < candidate.length
-          ellipsis = true
-          te = candidate.length - 2 if te > candidate.length
+          (te = candidate.length - 2) && (ellipsis = true) if te > candidate.length
           true
         else
           ts -= candidate.length

--- a/lib/halunke/source_code_position.rb
+++ b/lib/halunke/source_code_position.rb
@@ -6,26 +6,25 @@ module Halunke
     end
 
     def reveal(source, error_mode)
-      ts = @ts
-      te = @te
-      ellipsis = false
+      line, line_number = source.lines.each_with_index do |candidate, candidate_line_number|
+        break candidate, candidate_line_number if @ts < candidate.length
 
-      line, line_number = source.lines.each_with_index.find do |candidate, _line_number|
-        if ts < candidate.length
-          (te = candidate.length - 2) && (ellipsis = true) if te > candidate.length
-          true
-        else
-          ts -= candidate.length
-          te -= candidate.length
-          false
-        end
+        @ts -= candidate.length
+        @te -= candidate.length
+      end
+
+      if @te > line.length
+        @te = line.length - 2
+        ellipsis = '...'
       end
 
       prefix = error_mode == :repl ? ">> " : "#{line_number + 1} | "
 
       output = []
-      output << "#{prefix}#{line.rstrip}#{ellipsis ? '...' : ''}\n" if error_mode == :file
-      output << " " * (ts + prefix.length) + "^" * (te - ts + 1) + "\n\n"
+      output << [prefix, line.rstrip, ellipsis].join("") if error_mode == :file
+      output << " " * (@ts + prefix.length) + "^" * (@te - @ts + 1)
+      output << "\n"
+
       output
     end
   end

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -274,6 +274,12 @@ class InterpreterTest < Minitest::Test
     end
   end
 
+  def test_unknown_message_with_file_error_mode_and_line_break
+    assert_output(file_long_error_message) do
+      @interpreter.eval(%{("hello" replac "a"\n with "e")}, error_mode: :file)
+    end
+  end
+
   def test_unknown_message_with_repl_error_mode
     assert_output(repl_error_message) do
       @interpreter.eval(%{("hello" replac "a" with "e")}, error_mode: :repl)
@@ -303,9 +309,19 @@ class InterpreterTest < Minitest::Test
     PROGRAM
   end
 
+  def file_long_error_message
+    <<~ERROR_MESSAGE
+    1 | ("hello" replac "a"...
+        ^^^^^^^^^^^^^^^^^^^
+
+    "hello" received the message `replac with`. It doesn't know how to handle that.
+    Did you mean `replace with`?
+    ERROR_MESSAGE
+  end
+
   def file_error_message
     <<~ERROR_MESSAGE
-    1 | ("hello" replac "a" with "e")...
+    1 | ("hello" replac "a" with "e")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     "hello" received the message `replac with`. It doesn't know how to handle that.

--- a/test/nodes_test.rb
+++ b/test/nodes_test.rb
@@ -55,12 +55,11 @@ class NodesTest < Minitest::Test
   end
 
   def test_message_send
-    skip "convince minitest mock to expect a third argument"
     message = Object.new
     message_node = Minitest::Mock.new
     message_node.expect :eval, [message], [@context]
     receiver = Minitest::Mock.new
-    receiver.expect :receive_message, :result, [@context, message]
+    receiver.expect :receive_message, :result, [@context, message, any_keyword_arguments]
     receiver_node = Minitest::Mock.new
     receiver_node.expect :eval, receiver, [@context]
     node = Halunke::MessageSendNode.new(receiver_node, message_node)
@@ -118,5 +117,11 @@ class NodesTest < Minitest::Test
 
     node.eval(context)
     unassigned_bareword.verify
+  end
+
+  private
+
+  def any_keyword_arguments
+    Hash # Since Minitest::Mock will perform a === on each argument
   end
 end


### PR DESCRIPTION
* Fix skipped node_test `test_message_send`
* Only show ellipsis for actually too long lines
* Make SourceCodePosition a bit nicer, sort of, maybe 